### PR TITLE
Adds retry logic with time buff to `Filtering.cog_load()`

### DIFF
--- a/bot/exts/filtering/filtering.py
+++ b/bot/exts/filtering/filtering.py
@@ -154,7 +154,7 @@ class Filtering(Cog):
     def _retryable_filter_load_error(error: Exception) -> bool:
         """Return whether loading filter lists failed due to some temporary error, thus retrying could help."""
         if isinstance(error, ResponseCodeError):
-            return error.status == 429 or error.status >= 500
+            return error.status in (408, 429) or error.status >= 500
 
         return isinstance(error, (TimeoutError, OSError))
 

--- a/tests/bot/exts/filtering/test_filtering_cog.py
+++ b/tests/bot/exts/filtering/test_filtering_cog.py
@@ -80,6 +80,7 @@ class FilteringCogLoadTests(unittest.IsolatedAsyncioTestCase):
     def test_retryable_filter_load_error(self):
         """`_retryable_filter_load_error` should classify temporary failures as retryable."""
         test_cases = (
+            (ResponseCodeError(MagicMock(status=408)), True),
             (ResponseCodeError(MagicMock(status=429)), True),
             (ResponseCodeError(MagicMock(status=500)), True),
             (ResponseCodeError(MagicMock(status=503)), True),


### PR DESCRIPTION
## Summary


Previously, a temporary API outage (e.g. 5xx errors, 429 rate limiting, or network timeouts) would cause the Filtering cog to fail immediately. This change improves resilience by retrying a limited number of times before failing.

## Changes

- Introduced 3 attempt based retry
- Implemented exponential backoff (1s, 2s, 4s)
- Retry only on:
  - HTTP 429 (rate limiting)
  - HTTP 5xx responses
  - TimeoutError / OSError
- On final failure: it logs exception; alert #mod-alerts channel, 
- Added unit test covering startup failure behavior

## Testing

You can try raising an OSError in `line: 116`, and this should notify the mods in the respective channel. 
Example:
`raise OSError("Simulated site/API outage during cog_load")` 