### PR TITLE
Add retry logic with exponential backoff for `Reminders.cog_load()`

### DIFF
--- a/bot/exts/utils/reminders.py
+++ b/bot/exts/utils/reminders.py
@@ -240,6 +240,10 @@ class Reminders(Cog):
                 )
                 break
             except Exception as e:
+                if not self._check_error_is_retriable(e):
+                    log.error(f"Failed to load reminders due to non-retryable error: {e}")
+                    await self._alert_mods_if_loading_failed(e)
+                    raise
                 log.warning(f"Attempt {attempt} - Failed to fetch reminders from the API: {e}")
                 if attempt == MAX_RETRY_ATTEMPTS:
                     log.error("Max retry attempts reached. Failed to load reminders.")
@@ -278,6 +282,13 @@ class Reminders(Cog):
                 icon_url=Icons.token_removed,
                 colour=discord.Color.red()
             )
+
+    def _check_error_is_retriable(self, error: Exception) -> bool:
+        """Return whether loading filter lists failed due to some temporary error, thus retrying could help."""
+        if isinstance(error, ResponseCodeError):
+            return error.status in (408, 429) or error.status >= 500
+
+        return isinstance(error, (TimeoutError, OSError))
 
     def ensure_valid_reminder(self, reminder: dict) -> tuple[bool, discord.TextChannel]:
         """Ensure reminder channel can be fetched otherwise delete the reminder."""

--- a/tests/bot/exts/utils/test_reminders.py
+++ b/tests/bot/exts/utils/test_reminders.py
@@ -1,6 +1,8 @@
 import unittest
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from pydis_core.site_api import ResponseCodeError
+
 from bot.constants import URLs
 from bot.exts.utils.reminders import Reminders
 from tests.helpers import MockBot
@@ -35,7 +37,7 @@ class RemindersCogLoadTests(unittest.IsolatedAsyncioTestCase):
 
     async def test_reminders_cog_load_retries_after_initial_exception(self):
         """ Tests if the Reminders cog loads after retrying on initial exception. """
-        self.bot.api_client.get.side_effect = [Exception("fail 1"), Exception("fail 2"), []]
+        self.bot.api_client.get.side_effect = [OSError("fail1"), OSError("fail2"), []]
         try:
             with patch("bot.exts.utils.reminders.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
                 await self.cog.cog_load()
@@ -46,9 +48,10 @@ class RemindersCogLoadTests(unittest.IsolatedAsyncioTestCase):
 
     async def test_reminders_cog_load_fails_after_max_retries(self):
         """ Tests if the Reminders cog fails to load after max retries. """
-        self.bot.api_client.get.side_effect = RuntimeError("fail")
+        self.bot.api_client.get.side_effect = ResponseCodeError(response=MagicMock(status=500),
+                                                                response_text="Internal Server Error")
         with patch("bot.exts.utils.reminders.asyncio.sleep", new_callable=AsyncMock) as mock_sleep, \
-             self.assertRaises(RuntimeError):
+             self.assertRaises(ResponseCodeError):
             await self.cog.cog_load()
 
         # Should have retried MAX_RETRY_ATTEMPTS - 1 times before failing


### PR DESCRIPTION
## Summary 
- Added error propagation and retry logic in `Reminders.cog_load()` with corresponding unit tests

## Changes
- Introduced retry logic (the exact number of tries specified by `URLs.conect_max_retries` from `constants` package)
- Added warn logging to sentry
- Added a final alert, which sends a message to the `#mod-log` discord channel to alert the moderators of failed cog load
- Added unit tests for the retry functionality 

## Verification
- Newly created unit tests passed
- Added a simulated error on line 241 in `bot/ext/utils/reminders,py` -> the warnings were logged to sentry, and the final message was send to the discord channel